### PR TITLE
Implement simple token arcade backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# Ignore generated data file
+data.json
+__pycache__/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,43 @@
-# VAZSANA
+# Claw Machine Backend
+
+This repository contains a simple command line tool for recording
+operations of a token-based claw machine arcade. The tool keeps track of
+cash exchanges, stock entries for each machine and play results. Data is
+stored in `data.json` in the repository root.
+
+## Installation
+The project does not require external dependencies and works with
+Python 3.8+.
+
+## Usage
+Run the command line interface using:
+
+```bash
+python -m clawmachine.cli <command> [options]
+```
+
+Main commands:
+
+- `add-machine NAME` – register a new machine.
+- `cash-in AMOUNT` – record a cash exchange and calculate tokens.
+- `stock MACHINE_ID QUANTITY COST` – add stock to a machine with
+  specified unit cost.
+- `play MACHINE_ID TOKENS REWARDS` – log a play result (tokens used and
+  rewards taken).
+- `report-cash YYYY-MM-DD` – show total cash exchanged for a day.
+
+Example workflow:
+
+```bash
+python -m clawmachine.cli add-machine "Teddy Bear"
+python -m clawmachine.cli cash-in 1000
+python -m clawmachine.cli stock 1 20 50
+python -m clawmachine.cli play 1 15 3
+python -m clawmachine.cli report-cash $(date +%F)
+```
+
+Promotions for cash exchange are predefined in `data.json` on first run:
+
+- 1,000 baht ⇒ 55 tokens
+- 2,000 baht ⇒ 115 tokens
+- 4,000 baht ⇒ 240 tokens

--- a/clawmachine/cli.py
+++ b/clawmachine/cli.py
@@ -1,0 +1,113 @@
+import argparse
+from datetime import date
+
+from . import storage
+
+TOKEN_VALUE = 20
+
+def add_machine(args):
+    data = storage.load_data()
+    next_id = max([m['id'] for m in data['machines']], default=0) + 1
+    machine = {'id': next_id, 'name': args.name}
+    data['machines'].append(machine)
+    storage.save_data(data)
+    print(f"Added machine {next_id}: {args.name}")
+
+
+def cash_in(args):
+    data = storage.load_data()
+    promos = data.get('promotions', {})
+    tokens = promos.get(str(args.amount))
+    if tokens is None:
+        tokens = args.amount // TOKEN_VALUE
+    record = {
+        'date': str(date.today()),
+        'cash': args.amount,
+        'tokens': tokens
+    }
+    data['cash_ins'].append(record)
+    storage.save_data(data)
+    print(f"Cash in {args.amount} -> {tokens} tokens")
+
+
+def stock(args):
+    data = storage.load_data()
+    entry = {
+        'machine_id': args.machine_id,
+        'date': str(date.today()),
+        'quantity': args.quantity,
+        'cost_per_unit': args.cost
+    }
+    data['stock_entries'].append(entry)
+    storage.save_data(data)
+    print(
+        f"Stocked machine {args.machine_id} with {args.quantity} units at {args.cost} each"
+    )
+
+
+def play(args):
+    data = storage.load_data()
+    record = {
+        'machine_id': args.machine_id,
+        'date': str(date.today()),
+        'tokens_used': args.tokens,
+        'rewards_taken': args.rewards
+    }
+    data['plays'].append(record)
+    storage.save_data(data)
+    baht_value = args.tokens * TOKEN_VALUE
+    if args.rewards:
+        avg_price = baht_value / args.rewards
+        print(
+            f"Recorded play: {args.tokens} tokens ({baht_value} baht) -> {args.rewards} rewards (~{avg_price:.2f} baht each)"
+        )
+    else:
+        print(
+            f"Recorded play: {args.tokens} tokens ({baht_value} baht) -> no rewards"
+        )
+
+
+def report_cash(args):
+    data = storage.load_data()
+    total = sum(
+        r['cash'] for r in data['cash_ins'] if r['date'] == args.date
+    )
+    print(f"Cash in on {args.date}: {total} baht")
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description='Claw machine backend CLI')
+    sub = parser.add_subparsers()
+
+    m_add = sub.add_parser('add-machine', help='Add a new machine')
+    m_add.add_argument('name')
+    m_add.set_defaults(func=add_machine)
+
+    cash = sub.add_parser('cash-in', help='Record cash exchange for tokens')
+    cash.add_argument('amount', type=int)
+    cash.set_defaults(func=cash_in)
+
+    st = sub.add_parser('stock', help='Stock a machine with rewards')
+    st.add_argument('machine_id', type=int)
+    st.add_argument('quantity', type=int)
+    st.add_argument('cost', type=float)
+    st.set_defaults(func=stock)
+
+    pl = sub.add_parser('play', help='Record a play result')
+    pl.add_argument('machine_id', type=int)
+    pl.add_argument('tokens', type=int)
+    pl.add_argument('rewards', type=int)
+    pl.set_defaults(func=play)
+
+    rc = sub.add_parser('report-cash', help='Report cash-in for a date')
+    rc.add_argument('date', help='YYYY-MM-DD')
+    rc.set_defaults(func=report_cash)
+
+    args = parser.parse_args(argv)
+    if hasattr(args, 'func'):
+        args.func(args)
+    else:
+        parser.print_help()
+
+if __name__ == '__main__':
+    main()

--- a/clawmachine/storage.py
+++ b/clawmachine/storage.py
@@ -1,0 +1,23 @@
+import os
+import json
+from datetime import date
+
+DATA_FILE = os.path.join(os.path.dirname(__file__), '..', 'data.json')
+
+DEFAULT_DATA = {
+    "promotions": {"1000": 55, "2000": 115, "4000": 240},
+    "cash_ins": [],
+    "machines": [],
+    "stock_entries": [],
+    "plays": []
+}
+
+def load_data():
+    if os.path.exists(DATA_FILE):
+        with open(DATA_FILE, 'r') as f:
+            return json.load(f)
+    return DEFAULT_DATA.copy()
+
+def save_data(data):
+    with open(DATA_FILE, 'w') as f:
+        json.dump(data, f, indent=2)


### PR DESCRIPTION
## Summary
- add minimal README with usage instructions
- ignore runtime files with `.gitignore`
- implement simple JSON storage for arcade data
- create CLI tool supporting machine management, cash-in logging, stocking and play records

## Testing
- `python -m py_compile clawmachine/*.py`
